### PR TITLE
Fix spec warnings given on Ruby 1.9.3

### DIFF
--- a/lib/adapter/spec/an_adapter.rb
+++ b/lib/adapter/spec/an_adapter.rb
@@ -86,11 +86,11 @@ shared_examples_for "an adapter" do
   describe "#key?" do
     it "returns true if key available" do
       adapter.write(key, attributes)
-      adapter.key?(key).should be true
+      adapter.key?(key).should be(true)
     end
 
     it "returns false if key not available" do
-      adapter.key?(key).should be false
+      adapter.key?(key).should be(false)
     end
 
     it "accepts options" do
@@ -163,17 +163,17 @@ shared_examples_for "an adapter" do
     context "when key available" do
       it "removes key" do
         adapter.write(key, attributes)
-        adapter.key?(key).should be true
+        adapter.key?(key).should be(true)
         adapter.delete(key)
-        adapter.key?(key).should be false
+        adapter.key?(key).should be(false)
       end
     end
 
     context "when key not available" do
       it "does not complain" do
-        adapter.key?(key).should be false
+        adapter.key?(key).should be(false)
         adapter.delete(key)
-        adapter.key?(key).should be false
+        adapter.key?(key).should be(false)
       end
     end
 
@@ -188,11 +188,11 @@ shared_examples_for "an adapter" do
     it "removes all available keys" do
       adapter.write(key, attributes)
       adapter.write(key2, attributes2)
-      adapter.key?(key).should be true
-      adapter.key?(key2).should be true
+      adapter.key?(key).should be(true)
+      adapter.key?(key2).should be(true)
       adapter.clear
-      adapter.key?(key).should be false
-      adapter.key?(key2).should be false
+      adapter.key?(key).should be(false)
+      adapter.key?(key2).should be(false)
     end
 
     it "accepts options" do

--- a/lib/adapter/spec/an_adapter.rb
+++ b/lib/adapter/spec/an_adapter.rb
@@ -86,11 +86,11 @@ shared_examples_for "an adapter" do
   describe "#key?" do
     it "returns true if key available" do
       adapter.write(key, attributes)
-      adapter.key?(key).should be_true
+      adapter.key?(key).should be true
     end
 
     it "returns false if key not available" do
-      adapter.key?(key).should be_false
+      adapter.key?(key).should be false
     end
 
     it "accepts options" do
@@ -163,17 +163,17 @@ shared_examples_for "an adapter" do
     context "when key available" do
       it "removes key" do
         adapter.write(key, attributes)
-        adapter.key?(key).should be_true
+        adapter.key?(key).should be true
         adapter.delete(key)
-        adapter.key?(key).should be_false
+        adapter.key?(key).should be false
       end
     end
 
     context "when key not available" do
       it "does not complain" do
-        adapter.key?(key).should be_false
+        adapter.key?(key).should be false
         adapter.delete(key)
-        adapter.key?(key).should be_false
+        adapter.key?(key).should be false
       end
     end
 
@@ -188,11 +188,11 @@ shared_examples_for "an adapter" do
     it "removes all available keys" do
       adapter.write(key, attributes)
       adapter.write(key2, attributes2)
-      adapter.key?(key).should be_true
-      adapter.key?(key2).should be_true
+      adapter.key?(key).should be true
+      adapter.key?(key2).should be true
       adapter.clear
-      adapter.key?(key).should be_false
-      adapter.key?(key2).should be_false
+      adapter.key?(key).should be false
+      adapter.key?(key2).should be false
     end
 
     it "accepts options" do

--- a/spec/adapter_spec.rb
+++ b/spec/adapter_spec.rb
@@ -42,9 +42,9 @@ describe Adapter do
         Class.new do
           include Adapter.definitions[:memory]
         end.tap do |klass|
-          klass.new.respond_to?(:fetch).should be true
-          klass.new.respond_to?(:key?).should be true
-          klass.new.respond_to?(:read_multiple).should be true
+          klass.new.respond_to?(:fetch).should be(true)
+          klass.new.respond_to?(:key?).should be(true)
+          klass.new.respond_to?(:read_multiple).should be(true)
         end
       end
 
@@ -222,11 +222,11 @@ describe Adapter do
     describe "#key?" do
       it "returns true if key is set" do
         adapter.write('foo', 'bar')
-        adapter.key?('foo').should be true
+        adapter.key?('foo').should be(true)
       end
 
       it "returns false if key is not set" do
-        adapter.key?('foo').should be false
+        adapter.key?('foo').should be(false)
       end
     end
 

--- a/spec/adapter_spec.rb
+++ b/spec/adapter_spec.rb
@@ -42,9 +42,9 @@ describe Adapter do
         Class.new do
           include Adapter.definitions[:memory]
         end.tap do |klass|
-          klass.new.respond_to?(:fetch).should be_true
-          klass.new.respond_to?(:key?).should be_true
-          klass.new.respond_to?(:read_multiple).should be_true
+          klass.new.respond_to?(:fetch).should be true
+          klass.new.respond_to?(:key?).should be true
+          klass.new.respond_to?(:read_multiple).should be true
         end
       end
 
@@ -222,11 +222,11 @@ describe Adapter do
     describe "#key?" do
       it "returns true if key is set" do
         adapter.write('foo', 'bar')
-        adapter.key?('foo').should be_true
+        adapter.key?('foo').should be true
       end
 
       it "returns false if key is not set" do
-        adapter.key?('foo').should be_false
+        adapter.key?('foo').should be false
       end
     end
 


### PR DESCRIPTION
be_false and be_true are apparently deprecated.