### PR TITLE
Fix rspec deprecation warnings

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-source :rubygems
+source "https://rubygems.org"
 gemspec
 
 gem 'rake'

--- a/Gemfile
+++ b/Gemfile
@@ -11,5 +11,5 @@ group(:guard) do
 end
 
 group(:test) do
-  gem 'rspec'
+  gem 'rspec', '~> 3.4.0'
 end

--- a/lib/adapter/spec/an_adapter.rb
+++ b/lib/adapter/spec/an_adapter.rb
@@ -1,6 +1,6 @@
 shared_examples_for "an adapter" do
   it "can read the client" do
-    adapter.client.should == client
+    expect(adapter.client).to eq(client)
   end
 
   let(:key)  { 'key' }
@@ -24,14 +24,14 @@ shared_examples_for "an adapter" do
 
   describe "#read" do
     it "returns nil if key not available" do
-      adapter.read(key).should be_nil
+      expect(adapter.read(key)).to be_nil
     end
 
     it "returns attributes if key available" do
       adapter.write(key, attributes)
       result = adapter.read(key)
       attributes.each do |column, value|
-        result[column].should eq(value)
+        expect(result[column]).to eq(value)
       end
     end
 
@@ -52,11 +52,11 @@ shared_examples_for "an adapter" do
       result = adapter.read_multiple([key, key2])
 
       attributes.each do |column, value|
-        result[key][column].should eq(value)
+        expect(result[key][column]).to eq(value)
       end
 
       attributes2.each do |column, value|
-        result[key2][column].should eq(value)
+        expect(result[key2][column]).to eq(value)
       end
     end
 
@@ -65,14 +65,14 @@ shared_examples_for "an adapter" do
         result = adapter.read_multiple([key, key2, unavailable_key])
 
         attributes.each do |column, value|
-          result[key][column].should eq(value)
+          expect(result[key][column]).to eq(value)
         end
 
         attributes2.each do |column, value|
-          result[key2][column].should eq(value)
+          expect(result[key2][column]).to eq(value)
         end
 
-        result[unavailable_key].should be_nil
+        expect(result[unavailable_key]).to be_nil
       end
     end
 
@@ -86,11 +86,11 @@ shared_examples_for "an adapter" do
   describe "#key?" do
     it "returns true if key available" do
       adapter.write(key, attributes)
-      adapter.key?(key).should be(true)
+      expect(adapter.key?(key)).to be(true)
     end
 
     it "returns false if key not available" do
-      adapter.key?(key).should be(false)
+      expect(adapter.key?(key)).to be(false)
     end
 
     it "accepts options" do
@@ -104,13 +104,13 @@ shared_examples_for "an adapter" do
     context "with key not available" do
       context "with default attributes" do
         it "returns default" do
-          adapter.fetch(key, {}).should eq({})
+          expect(adapter.fetch(key, {})).to eq({})
         end
       end
 
       context "with default block" do
         it "returns value of yielded block" do
-          adapter.fetch(key) { |k| {} }.should eq({})
+          expect(adapter.fetch(key) { |k| {} }).to eq({})
         end
       end
     end
@@ -121,7 +121,7 @@ shared_examples_for "an adapter" do
           adapter.write(key, attributes2)
           result = adapter.fetch(key, attributes)
           attributes2.each do |column, value|
-            result[column].should eq(value)
+            expect(result[column]).to eq(value)
           end
         end
       end
@@ -131,7 +131,7 @@ shared_examples_for "an adapter" do
           adapter.write(key, attributes)
           unaltered = 'unaltered'
           adapter.fetch(key) { unaltered = 'altered' }
-          unaltered.should eq('unaltered')
+          expect(unaltered).to eq('unaltered')
         end
       end
     end
@@ -148,7 +148,7 @@ shared_examples_for "an adapter" do
       adapter.write(key, attributes)
       result = adapter.read(key)
       attributes.each do |column, value|
-        result[column].should eq(value)
+        expect(result[column]).to eq(value)
       end
     end
 
@@ -163,17 +163,17 @@ shared_examples_for "an adapter" do
     context "when key available" do
       it "removes key" do
         adapter.write(key, attributes)
-        adapter.key?(key).should be(true)
+        expect(adapter.key?(key)).to be(true)
         adapter.delete(key)
-        adapter.key?(key).should be(false)
+        expect(adapter.key?(key)).to be(false)
       end
     end
 
     context "when key not available" do
       it "does not complain" do
-        adapter.key?(key).should be(false)
+        expect(adapter.key?(key)).to be(false)
         adapter.delete(key)
-        adapter.key?(key).should be(false)
+        expect(adapter.key?(key)).to be(false)
       end
     end
 
@@ -188,11 +188,11 @@ shared_examples_for "an adapter" do
     it "removes all available keys" do
       adapter.write(key, attributes)
       adapter.write(key2, attributes2)
-      adapter.key?(key).should be(true)
-      adapter.key?(key2).should be(true)
+      expect(adapter.key?(key)).to be(true)
+      expect(adapter.key?(key2)).to be(true)
       adapter.clear
-      adapter.key?(key).should be(false)
-      adapter.key?(key2).should be(false)
+      expect(adapter.key?(key)).to be(false)
+      expect(adapter.key?(key2)).to be(false)
     end
 
     it "accepts options" do

--- a/spec/adapter_spec.rb
+++ b/spec/adapter_spec.rb
@@ -14,7 +14,7 @@ describe Adapter do
   describe ".definitions" do
     it "defaults to empty hash" do
       Adapter.instance_variable_set("@definitions", nil)
-      Adapter.definitions.should == {}
+      expect(Adapter.definitions).to eq({})
     end
   end
 
@@ -22,7 +22,7 @@ describe Adapter do
     describe "with string name" do
       it "symbolizes string adapter names" do
         Adapter.define('memory', valid_module)
-        Adapter.definitions.keys.should include(:memory)
+        expect(Adapter.definitions.keys).to include(:memory)
       end
     end
 
@@ -34,17 +34,17 @@ describe Adapter do
       let(:mod) { @mod }
 
       it "adds adapter to definitions" do
-        Adapter.definitions.should have_key(:memory)
-        Adapter.definitions[:memory].should be_instance_of(Module)
+        expect(Adapter.definitions).to have_key(:memory)
+        expect(Adapter.definitions[:memory]).to be_instance_of(Module)
       end
 
       it "includes the defaults" do
         Class.new do
           include Adapter.definitions[:memory]
         end.tap do |klass|
-          klass.new.respond_to?(:fetch).should be(true)
-          klass.new.respond_to?(:key?).should be(true)
-          klass.new.respond_to?(:read_multiple).should be(true)
+          expect(klass.new.respond_to?(:fetch)).to be(true)
+          expect(klass.new.respond_to?(:key?)).to be(true)
+          expect(klass.new.respond_to?(:read_multiple)).to be(true)
         end
       end
 
@@ -52,9 +52,9 @@ describe Adapter do
         it "raises error if #{method_name} is not defined in module" do
           mod.send(:undef_method, method_name)
 
-          lambda do
+          expect do
             Adapter.define(:memory, mod)
-          end.should raise_error(Adapter::IncompleteAPI, "Missing methods needed to complete API (#{method_name})")
+          end.to raise_error(Adapter::IncompleteAPI, "Missing methods needed to complete API (#{method_name})")
         end
       end
     end
@@ -81,11 +81,11 @@ describe Adapter do
       end
 
       it "adds adapter to definitions" do
-        Adapter.definitions.should have_key(:memory)
+        expect(Adapter.definitions).to have_key(:memory)
       end
 
       it "modularizes the block" do
-        Adapter.definitions[:memory].should be_instance_of(Module)
+        expect(Adapter.definitions[:memory]).to be_instance_of(Module)
       end
     end
 
@@ -101,10 +101,10 @@ describe Adapter do
       it "includes block after module" do
         adapter = Adapter[:memory].new({})
         adapter.write('foo', 'bar')
-        adapter.read('foo').should == 'bar'
-        lambda do
+        expect(adapter.read('foo')).to eq('bar')
+        expect do
           adapter.clear
-        end.should raise_error('Not Implemented')
+        end.to raise_error('Not Implemented')
       end
     end
   end
@@ -119,11 +119,11 @@ describe Adapter do
     end
 
     it "unmemoizes adapter by name" do
-      Adapter[:memory].should_not equal(@memoized_memory)
+      expect(Adapter[:memory]).not_to equal(@memoized_memory)
     end
 
     it "does not unmemoize other adapters" do
-      Adapter[:hash].should equal(@memoized_hash)
+      expect(Adapter[:hash]).to equal(@memoized_hash)
     end
   end
 
@@ -135,22 +135,22 @@ describe Adapter do
     it "returns adapter instance" do
       adapter = Adapter[:memory].new({})
       adapter.write('foo', 'bar')
-      adapter.read('foo').should == 'bar'
+      expect(adapter.read('foo')).to eq('bar')
       adapter.delete('foo')
-      adapter.read('foo').should be_nil
+      expect(adapter.read('foo')).to be_nil
       adapter.write('foo', 'bar')
       adapter.clear
-      adapter.read('foo').should be_nil
+      expect(adapter.read('foo')).to be_nil
     end
 
     it "raises error for undefined adapter" do
-      lambda do
+      expect do
         Adapter[:non_existant]
-      end.should raise_error(Adapter::Undefined)
+      end.to raise_error(Adapter::Undefined)
     end
 
     it "memoizes adapter by name" do
-      Adapter[:memory].should equal(Adapter[:memory])
+      expect(Adapter[:memory]).to equal(Adapter[:memory])
     end
   end
 
@@ -166,55 +166,55 @@ describe Adapter do
       it "works with options" do
         Adapter.define(:memory, valid_module)
         adapter = Adapter[:memory].new({}, :namespace => 'foo')
-        adapter.options[:namespace].should == 'foo'
+        expect(adapter.options[:namespace]).to eq('foo')
       end
     end
 
     describe "#name" do
       it "returns adapter name" do
-        adapter.name.should be(:memory)
+        expect(adapter.name).to be(:memory)
       end
     end
 
     describe "#fetch" do
       it "returns value if key found" do
         adapter.write('foo', 'bar')
-        adapter.fetch('foo', 'baz').should == 'bar'
+        expect(adapter.fetch('foo', 'baz')).to eq('bar')
       end
 
       it "returns default value if not key found" do
-        adapter.fetch('foo', 'baz').should == 'baz'
+        expect(adapter.fetch('foo', 'baz')).to eq('baz')
       end
 
       describe "with block" do
         it "returns value if key found" do
           adapter.write('foo', 'bar')
-          adapter.should_not_receive(:write)
-          adapter.fetch('foo') do
-            'baz'
-          end.should == 'bar'
+          expect(adapter).not_to receive(:write)
+          expect(adapter.fetch('foo') do
+                      'baz'
+                    end).to eq('bar')
         end
 
         it "returns default if key not found" do
-          adapter.fetch('foo', 'default').should == 'default'
+          expect(adapter.fetch('foo', 'default')).to eq('default')
         end
 
         it "returns result of block if key not found" do
-          adapter.fetch('foo') do
-            'baz'
-          end.should == 'baz'
+          expect(adapter.fetch('foo') do
+                      'baz'
+                    end).to eq('baz')
         end
 
         it "returns key if result of block writes key" do
-          adapter.fetch('foo', 'default') do
-            adapter.write('foo', 'write in block')
-          end.should == 'write in block'
+          expect(adapter.fetch('foo', 'default') do
+                      adapter.write('foo', 'write in block')
+                    end).to eq('write in block')
         end
 
         it "yields key to block" do
-          adapter.fetch('foo') do |key|
-            key
-          end.should == 'foo'
+          expect(adapter.fetch('foo') do |key|
+                      key
+                    end).to eq('foo')
         end
       end
     end
@@ -222,41 +222,41 @@ describe Adapter do
     describe "#key?" do
       it "returns true if key is set" do
         adapter.write('foo', 'bar')
-        adapter.key?('foo').should be(true)
+        expect(adapter.key?('foo')).to be(true)
       end
 
       it "returns false if key is not set" do
-        adapter.key?('foo').should be(false)
+        expect(adapter.key?('foo')).to be(false)
       end
     end
 
     describe "#eql?" do
       it "returns true if same name and client" do
-        adapter.should eql(Adapter[:memory].new({}))
+        expect(adapter).to eql(Adapter[:memory].new({}))
       end
 
       it "returns false if different name" do
         Adapter.define(:hash, valid_module)
-        adapter.should_not eql(Adapter[:hash].new({}))
+        expect(adapter).not_to eql(Adapter[:hash].new({}))
       end
 
       it "returns false if different client" do
-        adapter.should_not eql(Adapter[:memory].new(Object.new))
+        expect(adapter).not_to eql(Adapter[:memory].new(Object.new))
       end
     end
 
     describe "#==" do
       it "returns true if same name and client" do
-        adapter.should == Adapter[:memory].new({})
+        expect(adapter).to eq(Adapter[:memory].new({}))
       end
 
       it "returns false if different name" do
         Adapter.define(:hash, valid_module)
-        adapter.should_not == Adapter[:hash].new({})
+        expect(adapter).not_to eq(Adapter[:hash].new({}))
       end
 
       it "returns false if different client" do
-        adapter.should_not == Adapter[:memory].new(Object.new)
+        expect(adapter).not_to eq(Adapter[:memory].new(Object.new))
       end
     end
   end


### PR DESCRIPTION
This brings the gem up to latest rspec syntax and explicitly sets the gem version so authors of other adapters can easily target a compatible version of rspec.

This comes from trying to bring `adapter-mongo` up to the latest version of the mongo gem and having a hard time figuring out the exact right version of `rspec` to run. If you have another approach you think would be better, I'm open.
